### PR TITLE
Update Slack password requirements

### DIFF
--- a/content/slack.json
+++ b/content/slack.json
@@ -9,7 +9,7 @@
         {
             "name": "Requirements",
             "shortcuts": [
-                "6 characters or more"
+                "8 characters or more"
             ]
         },
         {


### PR DESCRIPTION
Slack recently updated the password length to 8 characters